### PR TITLE
Styles BEM pour formulaires et états focus/disabled pour boutons

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -15,6 +15,17 @@
     &:hover {
       background-color: var(--black-hover);
     }
+     &:focus {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+    }
+
+    &:disabled {
+    background-color: var(--grey);
+    color: var(--white);
+    cursor: not-allowed;
+    opacity: 0.6;
+    }
 
     // modifiers de couleur
     &--primary {

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -1,0 +1,43 @@
+@use "../partials/functions" as f;
+@use "../partials/variables" as v;
+
+@layer components {
+  .form {
+    &__label {
+      display: block;
+      margin-bottom: f.rem(8);
+      font-weight: 600;
+      color: var(--text-color);
+    }
+
+    &__input {
+      width: 100%;
+      padding: f.rem(8) f.rem(12);
+      border: 1px solid var(--border-color);
+      border-radius: f.rem(6);
+      background-color: var(--bg-input);
+      color: var(--text-color);
+      font-size: f.rem(16);
+      line-height: f.rem(20);
+      transition: border-color 0.2s, box-shadow 0.2s;
+
+      &:focus {
+        border-color: var(--blue);
+        outline: none;
+        box-shadow: 0 0 0 2px var(--blue-hover);
+      }
+
+      &:disabled {
+        background-color: var(--grey);
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+
+    &__error {
+      margin-top: f.rem(4);
+      font-size: f.rem(14);
+      color: var(--red);
+    }
+  }
+}


### PR DESCRIPTION
- Création de scss/components/_forms.scss pour styliser les formulaires :
  - Labels (.form__label)
  - Inputs (.form__input)
  - Messages d'erreur (.form__error)
  - Gestion des états : :focus, :disabled
  - Support Dark Mode via les variables CSS

- Mise à jour de scss/components/_button.scss :
  - Ajout des états :focus et :disabled
  - Maintien des modifiers existants (--primary, --secondary, --danger, --lg, --sm)

- Import du fichier _forms.scss dans main.scss pour compilation.

Tests effectués :
- Vérification visuelle des inputs et boutons
- Vérification des états :hover, :focus, :disabled
- Dark Mode fonctionnel
- Les boutons existants et les autres pages restent intacts