### PR TITLE
feat: add CSRF protection utility

### DIFF
--- a/app/src/Lib/Security/Csrf.php
+++ b/app/src/Lib/Security/Csrf.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Lib\Security;
+
+class Csrf
+{
+    private const SESSION_KEY = 'csrf_token';
+    private const ERROR_INVALID_TOKEN = 'Invalid CSRF token';
+
+    public static function generate(): string
+    {
+        self::ensureSessionStarted();
+
+        $token = bin2hex(random_bytes(32));
+        $_SESSION[self::SESSION_KEY] = $token;
+
+        return $token;
+    }
+
+    public static function verify(?string $token): void
+    {
+        self::ensureSessionStarted();
+
+        if (!self::isTokenValid($token)) {
+            http_response_code(403);
+            throw new \Exception(self::ERROR_INVALID_TOKEN);
+        }
+    }
+
+    private static function isTokenValid(?string $token): bool
+    {
+        return !empty($token)
+            && !empty($_SESSION[self::SESSION_KEY])
+            && hash_equals($_SESSION[self::SESSION_KEY], $token);
+    }
+
+    private static function ensureSessionStarted(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a reusable CSRF protection utility.

A dedicated CSRF class has been added to generate secure tokens, store them in session, and validate incoming requests.
The validation logic is centralized, reusable, and ensures invalid or missing tokens are rejected with a proper HTTP 403 response.