### PR TITLE
feat: add transient cache to ApiClient

### DIFF
--- a/app/config/database.json
+++ b/app/config/database.json
@@ -1,7 +1,7 @@
 {
-  "host": "db",
+  "host": "cms_db",
   "user": "root",
-  "password": "password",
-  "database": "db",
+  "password": "root",
+  "database": "cms_db",
   "port": 3306
 }

--- a/app/config/routes.json
+++ b/app/config/routes.json
@@ -44,6 +44,13 @@
     "middleware": "AdminMiddleware"
   },
   {
+    "method": "POST",
+    "path": "/admin/clear-cache",
+    "controller": "DashboardController",
+    "action": "clearCache",
+    "middleware": "AdminMiddleware"
+  },
+  {
     "method": "GET",
     "path": "/admin/posts",
     "controller": "AdminPostController",

--- a/app/src/Controllers/DashboardController.php
+++ b/app/src/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Lib\Controllers\AbstractController;
 use App\Lib\Http\Request;
 use App\Lib\Http\Response;
 use App\Core\Session;
+use App\Lib\Cache\TransientManager;
 
 class DashboardController extends AbstractController
 {
@@ -23,5 +24,17 @@ class DashboardController extends AbstractController
             ['title' => 'Dashboard Admin', 'user' => $user],
             'admin'                  
         );
+    }
+
+    public function clearCache(Request $request): Response
+    {
+        TransientManager::init();
+        TransientManager::clear();
+
+        $response = new Response();
+        $response->setStatus(302);
+        $response->addHeader('Location', '/admin');
+        
+        return $response;
     }
 }

--- a/app/src/Lib/Cache/TransientManager.php
+++ b/app/src/Lib/Cache/TransientManager.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Lib\Cache;
+
+class TransientManager
+{
+    private static array $transients = [];
+    private static string $storagePath;
+
+    public static function init(string $storagePath = null): void
+    {
+        if ($storagePath === null) {
+            $storagePath = __DIR__ . '/../../../log/transients';
+        }
+        self::$storagePath = $storagePath;
+        
+        if (!is_dir($storagePath)) {
+            mkdir($storagePath, 0755, true);
+        }
+        
+        self::loadTransients();
+    }
+
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        if (!isset(self::$transients[$key])) {
+            return $default;
+        }
+
+        $transient = self::$transients[$key];
+
+        if ($transient['expires_at'] !== 0 && time() > $transient['expires_at']) {
+            self::delete($key);
+            return $default;
+        }
+
+        return $transient['value'];
+    }
+
+    public static function set(string $key, mixed $value, int $expiration = 3600): bool
+    {
+        $expiresAt = ($expiration === 0) ? 0 : time() + $expiration;
+
+        self::$transients[$key] = [
+            'value' => $value,
+            'expires_at' => $expiresAt,
+        ];
+
+        return self::saveTransients();
+    }
+
+    public static function delete(string $key): bool
+    {
+        if (isset(self::$transients[$key])) {
+            unset(self::$transients[$key]);
+            return self::saveTransients();
+        }
+        return true;
+    }
+
+    public static function clear(): bool
+    {
+        self::$transients = [];
+        return self::saveTransients();
+    }
+
+    private static function loadTransients(): void
+    {
+        if (!self::$storagePath) {
+            return;
+        }
+
+        $file = self::$storagePath . '/transients.json';
+        if (file_exists($file)) {
+            $content = file_get_contents($file);
+            $data = json_decode($content, true);
+            if ($data) {
+                self::$transients = $data;
+            }
+        }
+    }
+
+    private static function saveTransients(): bool
+    {
+        if (!self::$storagePath) {
+            return true;
+        }
+
+        $file = self::$storagePath . '/transients.json';
+        $json = json_encode(self::$transients, JSON_PRETTY_PRINT);
+        return file_put_contents($file, $json) !== false;
+    }
+}

--- a/app/src/Lib/Http/ApiClient.php
+++ b/app/src/Lib/Http/ApiClient.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Lib\Http;
+
+use App\Lib\Cache\TransientManager;
+
+class ApiClient
+{
+    private int $timeout = 10;
+    private array $defaultHeaders = [];
+    private int $cacheExpiration = 3600;
+
+    public function __construct()
+    {
+        TransientManager::init();
+    }
+
+    public function setTimeout(int $timeout): self
+    {
+        $this->timeout = $timeout;
+        return $this;
+    }
+
+    public function addHeader(string $key, string $value): self
+    {
+        $this->defaultHeaders[$key] = $value;
+        return $this;
+    }
+
+    public function setCacheExpiration(int $seconds): self
+    {
+        $this->cacheExpiration = $seconds;
+        return $this;
+    }
+
+    public function getCached(string $url, array $params = [], ?int $cacheExpiration = null): ?array
+    {
+        $cacheKey = $this->generateCacheKey('GET', $url, $params);
+
+        $cached = TransientManager::get($cacheKey);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $result = $this->get($url, $params);
+
+        if ($result !== null) {
+            $expiration = $cacheExpiration ?? $this->cacheExpiration;
+            TransientManager::set($cacheKey, $result, $expiration);
+        }
+
+        return $result;
+    }
+
+    public function get(string $url, array $params = []): ?array
+    {
+        if (!empty($params)) {
+            $url .= '?' . http_build_query($params);
+        }
+
+        return $this->request('GET', $url);
+    }
+
+    public function post(string $url, array $data = []): ?array
+    {
+        return $this->request('POST', $url, $data);
+    }
+
+    public function put(string $url, array $data = []): ?array
+    {
+        return $this->request('PUT', $url, $data);
+    }
+
+    public function delete(string $url): ?array
+    {
+        return $this->request('DELETE', $url);
+    }
+
+    public function invalidateCache(string $url, array $params = []): void
+    {
+        $cacheKey = $this->generateCacheKey('GET', $url, $params);
+        TransientManager::delete($cacheKey);
+    }
+
+    private function request(string $method, string $url, array $data = []): ?array
+    {
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+
+        $headers = $this->prepareHeaders();
+        if (!empty($headers)) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        }
+
+        if (!empty($data) && in_array($method, ['POST', 'PUT'])) {
+            $jsonData = json_encode($data);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonData);
+        }
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+
+        curl_close($ch);
+
+        if ($error) {
+            error_log("ApiClient Error: $error");
+            return null;
+        }
+
+        if ($httpCode < 200 || $httpCode >= 300) {
+            error_log("ApiClient HTTP Error: $httpCode - $response");
+            return null;
+        }
+
+        return $this->parseResponse($response);
+    }
+
+    private function prepareHeaders(): array
+    {
+        $headers = [];
+        
+        foreach ($this->defaultHeaders as $key => $value) {
+            $headers[] = "$key: $value";
+        }
+
+        if (empty($this->defaultHeaders['Content-Type'])) {
+            $headers[] = 'Content-Type: application/json';
+        }
+
+        return $headers;
+    }
+
+    private function parseResponse(string $response): ?array
+    {
+        $data = json_decode($response, true);
+        return $data ?? ['raw' => $response];
+    }
+
+    private function generateCacheKey(string $method, string $url, array $params = []): string
+    {
+        $key = $method . ':' . $url;
+        if (!empty($params)) {
+            $key .= ':' . md5(json_encode($params));
+        }
+        return md5($key);
+    }
+}

--- a/app/views/admin/dashboard.html
+++ b/app/views/admin/dashboard.html
@@ -9,3 +9,9 @@
     <a href="/admin/posts" class="button">Voir les articles</a>
   </div>
 </div>
+<div style="margin-top: 30px; padding: 20px; background-color: #f5f5f5; border-radius: 8px;">
+  <h3>Cache</h3>
+  <form method="POST" action="/admin/clear-cache" style="display: inline;">
+    <button type="submit" class="button" style="background-color: #ff6b6b; color: white;">Vider le cache</button>
+  </form>
+</div>


### PR DESCRIPTION
## 🚀 API Cache Transient - Caching System

### 📝 Description
Ajout d'un système de cache transient pour les appels API avec gestion automatique de l'expiration. Permet d'optimiser les performances en mettant en cache les réponses des API externes et de les réutiliser pendant une période définie.

### ✨ Fonctionnalités

#### 1. **TransientManager** (`app/src/Lib/Cache/TransientManager.php`)
- Système de cache simple et léger basé sur JSON
- Gestion automatique de l'expiration des données
- Stockage persistant dans `log/transients/transients.json`
- Méthodes principales :
  - `get(key, default)` - Récupère une valeur (retourne null/default si expiré)
  - `set(key, value, expiration)` - Stocke une valeur avec expiration en secondes
  - `delete(key)` - Supprime une entrée
  - `clear()` - Vide complètement le cache

#### 2. **ApiClient Amélioré** (`app/src/Lib/Http/ApiClient.php`)
- Nouvelle méthode `getCached(url, params, expiration)` 
- Cache automatique des réponses GET
- Configuration flexible de l'expiration par défaut (3600s = 1h)
- Méthode `invalidateCache(url, params)` pour invalider manuellement
- REST complet : GET, POST, PUT, DELETE

#### 3. **Dashboard Admin**
- Nouvelle route POST `/admin/clear-cache` protégée par AdminMiddleware
- Bouton "Vider le cache" dans le dashboard
- Permet aux admins de forcer l'invalidation du cache

### 🔧 Configuration
- Expiration par défaut : **3600 secondes (1 heure)**
- Stockage : **`log/transients/transients.json`**
- Mise à jour database.json : host/credentials actualisés

### 💡 Utilisation

```php
$apiClient = new ApiClient();

// Récupérer avec cache (1 heure par défaut)
$data = $apiClient->getCached('https://api.example.com/users');

// Avec expiration custom (30 min)
$data = $apiClient->getCached('https://api.example.com/users', [], 1800);

// Invalider manuellement
$apiClient->invalidateCache('https://api.example.com/users');